### PR TITLE
Image.Resampling.LANCZOS instead of Image.ANTIALIAS deprecated in Pillow 10

### DIFF
--- a/imagedominantcolor/dominantcolor.py
+++ b/imagedominantcolor/dominantcolor.py
@@ -17,7 +17,7 @@ class DominantColor:
         self.b: int = 0
         self.l: int = 0
         self.resized_image = self.image.resize(
-            (DominantColor.resize_value, DominantColor.resize_value), Image.ANTIALIAS
+            (DominantColor.resize_value, DominantColor.resize_value), Image.Resampling.LANCZOS
         ).convert("RGBA")
         self.image.close()
         self.image_data = self.resized_image.getdata()


### PR DESCRIPTION
[Pillow's release notes](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html)

[PR ](https://github.com/akamhy/videohash/pull/109) also done in your other project videohash.